### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to bbx_audio will be documented in this file.
 
+## [0.5.0] - 2026-08-06
+
+### Features
+
+- Add Electrosmith Daisy hardware support: new no_std `bbx_daisy` crate with SAI/DMA audio, board init macros, codec drivers, and on-device examples (#116) ([#116](https://github.com/blackboxaudio/bbx_audio/pull/116))
+- Add `no_std` support to `bbx_core`, `bbx_dsp`, and `bbx_midi` via a `std`/`alloc` feature lattice (#116) ([#116](https://github.com/blackboxaudio/bbx_audio/pull/116))
+- Route all DSP math through `libm` (`bbx_core::math::Real`) for bit-identical results across std and no_std builds (#116) ([#116](https://github.com/blackboxaudio/bbx_audio/pull/116))
+- Add `Source` trait to `bbx_player` for playback abstractions
+- Enable the STM32H750 double-precision FPU in embedded builds (`-C target-cpu=cortex-m7`)
+- Add `08_cycle_check` example measuring on-device DSP cost with the DWT cycle counter
+
+### Bug Fixes
+
+- Add `prepare`/`reset` methods to handle DSP context changes (#112) ([#112](https://github.com/blackboxaudio/bbx_audio/pull/112))
+- Add a `std` feature (default) to `bbx_plugin` so it builds without `simd`
+- Harden the Daisy audio ISR: startup ordering vs NVIC unmask, explicit interrupt priority, atomic control sharing, cache-line-guaranteed DMA buffers, bounded SAI startup wait
+
+### Breaking Changes
+
+- Rename `AudioBuffer` to `SampleBuffer`; move the `Buffer` trait to `bbx_core` (#116) ([#116](https://github.com/blackboxaudio/bbx_audio/pull/116))
+- Combine `Graph` prepare methods (#114) ([#114](https://github.com/blackboxaudio/bbx_audio/pull/114))
+- `bbx_daisy`'s `set_callback` and `init_and_start` now return `Result<(), AudioError>`
+
 ## [0.4.3] - 2026-01-15
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,7 @@ checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
 
 [[package]]
 name = "bbx_core"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "libm",
  "loom",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "bbx_daisy"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "bbx_core",
  "bbx_dsp",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "bbx_draw"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "bbx_core",
  "bbx_dsp",
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "bbx_dsp"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "bbx_core",
  "bbx_midi",
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "bbx_file"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "bbx_core",
  "bbx_dsp",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "bbx_midi"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "bbx_core",
  "midir",
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "bbx_net"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "bbx_core",
  "futures-util",
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "bbx_player"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "bbx_core",
  "bbx_dsp",
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "bbx_plugin"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "bbx_core",
  "bbx_dsp",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "bbx_sandbox"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "bbx_core",
  "bbx_dsp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.3"
+version = "0.5.0"
 authors = ["Black Box Audio, LLC"]
 edition = "2024"
 license = "MIT"
@@ -24,14 +24,14 @@ rust-version = "1.89.0"
 [workspace.dependencies]
 # Internal crates (version + path for publishing)
 # Note: default-features = false allows individual crates to opt-in to features
-bbx_core = { version = "0.4.3", path = "bbx_core", default-features = false }
-bbx_daisy = { version = "0.4.3", path = "bbx_daisy" }
-bbx_dsp = { version = "0.4.3", path = "bbx_dsp", default-features = false }
-bbx_file = { version = "0.4.3", path = "bbx_file" }
-bbx_midi = { version = "0.4.3", path = "bbx_midi", default-features = false }
-bbx_net = { version = "0.4.3", path = "bbx_net", default-features = false }
-bbx_player = { version = "0.4.3", path = "bbx_player", default-features = false }
-bbx_plugin = { version = "0.4.3", path = "bbx_plugin" }
+bbx_core = { version = "0.5.0", path = "bbx_core", default-features = false }
+bbx_daisy = { version = "0.5.0", path = "bbx_daisy" }
+bbx_dsp = { version = "0.5.0", path = "bbx_dsp", default-features = false }
+bbx_file = { version = "0.5.0", path = "bbx_file" }
+bbx_midi = { version = "0.5.0", path = "bbx_midi", default-features = false }
+bbx_net = { version = "0.5.0", path = "bbx_net", default-features = false }
+bbx_player = { version = "0.5.0", path = "bbx_player", default-features = false }
+bbx_plugin = { version = "0.5.0", path = "bbx_plugin" }
 
 # External dependencies
 cpal = "0.15.3"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Test](https://github.com/blackboxaudio/bbx_audio/actions/workflows/ci.test.yml/badge.svg)](https://github.com/blackboxaudio/bbx_audio/actions/workflows/ci.test.yml)
 [![Clippy](https://github.com/blackboxaudio/bbx_audio/actions/workflows/ci.clippy.yml/badge.svg)](https://github.com/blackboxaudio/bbx_audio/actions/workflows/ci.clippy.yml)
-[![Version: v0.4.3](https://img.shields.io/badge/Version-v0.4.3-blue.svg)](https://github.com/blackboxaudio/bbx_audio)
+[![Version: v0.5.0](https://img.shields.io/badge/Version-v0.5.0-blue.svg)](https://github.com/blackboxaudio/bbx_audio)
 [![License](https://img.shields.io/badge/License-MIT-yellow)](https://github.com/blackboxaudio/bbx_audio/blob/develop/LICENSE)
 
 A modular, real-time safe audio toolkit in Rust.

--- a/bbx_daisy/README.md
+++ b/bbx_daisy/README.md
@@ -38,7 +38,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bbx_daisy = { version = "0.4.3", default-features = false, features = ["seed"] }
+bbx_daisy = { version = "0.5.0", default-features = false, features = ["seed"] }
 ```
 
 ### Audio Processing
@@ -221,7 +221,7 @@ wait states at 400+ MHz — and the data cache helps data-heavy work (big waveta
 delay lines). If the default already keeps up, leave it off: it's the simpler, verified path.
 
 ```toml
-bbx_daisy = { version = "0.4.3", default-features = false, features = ["seed", "dcache"] }
+bbx_daisy = { version = "0.5.0", default-features = false, features = ["seed", "dcache"] }
 ```
 
 **Before shipping with it on:**

--- a/bbx_net/README.md
+++ b/bbx_net/README.md
@@ -13,9 +13,9 @@ Enable protocols via feature flags:
 
 ```toml
 [dependencies]
-bbx_net = { version = "0.4", features = ["osc"] }        # OSC only
-bbx_net = { version = "0.4", features = ["websocket"] }  # WebSocket only
-bbx_net = { version = "0.4", features = ["full"] }       # Both protocols
+bbx_net = { version = "0.5", features = ["osc"] }        # OSC only
+bbx_net = { version = "0.5", features = ["websocket"] }  # WebSocket only
+bbx_net = { version = "0.5", features = ["full"] }       # Both protocols
 ```
 
 ## Quick Start

--- a/bbx_net/client/package.json
+++ b/bbx_net/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bbx-audio/net",
-    "version": "0.4.3",
+    "version": "0.5.0",
     "description": "Lightweight client for websocket-based audio control with the bbx_net 🌐",
     "private": false,
     "license": "MIT",

--- a/docs/src/crates/bbx-daisy.md
+++ b/docs/src/crates/bbx-daisy.md
@@ -15,7 +15,7 @@ bbx_daisy provides:
 
 ```toml
 [dependencies]
-bbx_daisy = { version = "0.4", features = ["seed"] }
+bbx_daisy = { version = "0.5", features = ["seed"] }
 ```
 
 ## Features

--- a/docs/src/crates/bbx-net.md
+++ b/docs/src/crates/bbx-net.md
@@ -18,9 +18,9 @@ Enable protocols via feature flags:
 
 ```toml
 [dependencies]
-bbx_net = { version = "0.4", features = ["osc"] }        # OSC only
-bbx_net = { version = "0.4", features = ["websocket"] }  # WebSocket only
-bbx_net = { version = "0.4", features = ["full"] }       # Both protocols
+bbx_net = { version = "0.5", features = ["osc"] }        # OSC only
+bbx_net = { version = "0.5", features = ["websocket"] }  # WebSocket only
+bbx_net = { version = "0.5", features = ["full"] }       # Both protocols
 ```
 
 ## Features

--- a/docs/src/crates/bbx-player.md
+++ b/docs/src/crates/bbx-player.md
@@ -15,8 +15,8 @@ bbx_player provides:
 
 ```toml
 [dependencies]
-bbx_player = "0.4"              # Default rodio backend
-bbx_player = { version = "0.4", features = ["cpal"], default-features = false }  # cpal only
+bbx_player = "0.5"              # Default rodio backend
+bbx_player = { version = "0.5", features = ["cpal"], default-features = false }  # cpal only
 ```
 
 ## Features

--- a/docs/src/crates/net/osc.md
+++ b/docs/src/crates/net/osc.md
@@ -12,7 +12,7 @@ Add bbx_net with the `osc` feature:
 
 ```toml
 [dependencies]
-bbx_net = { version = "0.4", features = ["osc"] }
+bbx_net = { version = "0.5", features = ["osc"] }
 ```
 
 ## Basic Usage

--- a/docs/src/crates/net/websocket.md
+++ b/docs/src/crates/net/websocket.md
@@ -12,7 +12,7 @@ Add bbx_net with the `websocket` feature:
 
 ```toml
 [dependencies]
-bbx_net = { version = "0.4", features = ["websocket"] }
+bbx_net = { version = "0.5", features = ["websocket"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -11,29 +11,29 @@ Add the crates you need to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bbx_dsp = "0.4.3"
-bbx_core = "0.4.3"
+bbx_dsp = "0.5.0"
+bbx_core = "0.5.0"
 ```
 
 For JUCE plugin integration, you'll only need:
 
 ```toml
 [dependencies]
-bbx_plugin = "0.4.3"
+bbx_plugin = "0.5.0"
 ```
 
 For audio file I/O:
 
 ```toml
 [dependencies]
-bbx_file = "0.4.3"
+bbx_file = "0.5.0"
 ```
 
 For MIDI support:
 
 ```toml
 [dependencies]
-bbx_midi = "0.4.3"
+bbx_midi = "0.5.0"
 ```
 
 ## Using Git Dependencies

--- a/docs/src/tutorials/osc-audio.md
+++ b/docs/src/tutorials/osc-audio.md
@@ -25,8 +25,8 @@ Add OSC support to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bbx_net = { version = "0.4", features = ["osc"] }
-bbx_dsp = "0.4"
+bbx_net = { version = "0.5", features = ["osc"] }
+bbx_dsp = "0.5"
 ```
 
 ## Core Concepts

--- a/docs/src/tutorials/terminal-synth.md
+++ b/docs/src/tutorials/terminal-synth.md
@@ -40,7 +40,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-bbx_dsp = "0.4.3"
+bbx_dsp = "0.5.0"
 rodio = "0.20.1"
 ```
 
@@ -165,7 +165,7 @@ Add the `bbx_dsp` block import:
 
 ```toml
 [dependencies]
-bbx_dsp = "0.4.3"
+bbx_dsp = "0.5.0"
 rodio = "0.20.1"
 ```
 
@@ -248,7 +248,7 @@ Update `Cargo.toml`:
 
 ```toml
 [dependencies]
-bbx_dsp = "0.4.3"
+bbx_dsp = "0.5.0"
 bbx_midi = "0.1.0"
 rodio = "0.20.1"
 midir = "0.11"

--- a/docs/src/tutorials/websocket-audio.md
+++ b/docs/src/tutorials/websocket-audio.md
@@ -25,8 +25,8 @@ Add WebSocket support to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bbx_net = { version = "0.4", features = ["websocket"] }
-bbx_dsp = "0.4"
+bbx_net = { version = "0.5", features = ["websocket"] }
+bbx_dsp = "0.5"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 


### PR DESCRIPTION
Lockstep version bump `0.4.3` → `0.5.0` across the workspace, npm client, README badge, CHANGELOG, and every dependency snippet in per-crate READMEs and `docs/src`.

**Merging this PR triggers the Release workflow** (`cd.release.yml`): tag `v0.5.0`, develop→main sync PR, validation, crates.io publish chain (core → midi → net → dsp → file → player → plugin → draw → daisy), npm publish of `@bbx-audio/net`, and the GitHub Release.

Highlights going out in 0.5.0 (see CHANGELOG):
- Electrosmith Daisy hardware support (`bbx_daisy`) with hardened SAI/DMA audio path
- `no_std` support for `bbx_core`/`bbx_dsp`/`bbx_midi`; libm-unified DSP math
- Double-precision FPU enabled for embedded builds
- Breaking: `AudioBuffer` → `SampleBuffer`, `Buffer` trait moved to `bbx_core`

Pre-merge validation (local, since Actions is currently not executing): full release battery green — fmt ✅ clippy (incl. `--all-targets`) ✅ 24/24 test suites ✅ desktop + full embedded feature-matrix builds ✅ version-matches-tag check ✅ package contents clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)