### PR TITLE
fix(dsp): clamp block processing to the output slice length

### DIFF
--- a/bbx_dsp/src/blocks/generators/oscillator.rs
+++ b/bbx_dsp/src/blocks/generators/oscillator.rs
@@ -92,13 +92,16 @@ impl<S: Sample> Block<S> for OscillatorBlock<S> {
 
         let phase_increment = freq.to_f64() / context.sample_rate * S::TAU.to_f64();
 
+        // Callers may pass slices shorter than the graph's block size
+        // (e.g. sample-accurate event splitting), so clamp to the slice
+        let num_samples = context.buffer_size.min(outputs[0].len());
+
         #[cfg(feature = "simd")]
         {
             use crate::waveform::DEFAULT_DUTY_CYCLE;
 
             if !matches!(self.waveform, Waveform::Noise) {
-                let buffer_size = context.buffer_size;
-                let chunks = buffer_size / SIMD_LANES;
+                let chunks = num_samples / SIMD_LANES;
                 let remainder_start = chunks * SIMD_LANES;
                 let chunk_phase_step = phase_increment * SIMD_LANES as f64;
 
@@ -142,7 +145,7 @@ impl<S: Sample> Block<S> for OscillatorBlock<S> {
                 self.phase = self.phase.rem_euclid(S::TAU.to_f64());
 
                 process_waveform_scalar(
-                    &mut outputs[0][remainder_start..],
+                    &mut outputs[0][remainder_start..num_samples],
                     self.waveform,
                     &mut self.phase,
                     phase_increment,
@@ -151,7 +154,7 @@ impl<S: Sample> Block<S> for OscillatorBlock<S> {
                 );
             } else {
                 process_waveform_scalar(
-                    outputs[0],
+                    &mut outputs[0][..num_samples],
                     self.waveform,
                     &mut self.phase,
                     phase_increment,
@@ -164,7 +167,7 @@ impl<S: Sample> Block<S> for OscillatorBlock<S> {
         #[cfg(not(feature = "simd"))]
         {
             process_waveform_scalar(
-                outputs[0],
+                &mut outputs[0][..num_samples],
                 self.waveform,
                 &mut self.phase,
                 phase_increment,
@@ -610,6 +613,66 @@ mod tests {
                 POLYBLEP_TOLERANCE
             );
         }
+    }
+
+    #[test]
+    fn test_short_slice_output_f32() {
+        let mut osc = OscillatorBlock::<f32>::new(440.0, Waveform::Sine, Some(42));
+        let context = test_context(512);
+        let inputs: [&[f32]; 0] = [];
+
+        // Shorter than buffer_size and not a multiple of the SIMD width
+        let mut output = vec![0.0f32; 250];
+        let mut outputs: [&mut [f32]; 1] = [&mut output];
+        osc.process(&inputs, &mut outputs, &[], &context);
+
+        let max = output.iter().fold(0.0f32, |acc, &x| acc.max(x.abs()));
+        assert!(max > 0.5, "Short slice should still produce signal, max={}", max);
+    }
+
+    #[test]
+    fn test_short_slice_phase_continuity_f32() {
+        let context = test_context(512);
+        let inputs: [&[f32]; 0] = [];
+
+        let mut split_osc = OscillatorBlock::<f32>::new(440.0, Waveform::Sine, Some(42));
+        let mut buffer1 = vec![0.0f32; 250];
+        let mut buffer2 = vec![0.0f32; 250];
+        {
+            let mut outputs: [&mut [f32]; 1] = [&mut buffer1];
+            split_osc.process(&inputs, &mut outputs, &[], &context);
+        }
+        {
+            let mut outputs: [&mut [f32]; 1] = [&mut buffer2];
+            split_osc.process(&inputs, &mut outputs, &[], &context);
+        }
+
+        let mut continuous_osc = OscillatorBlock::<f32>::new(440.0, Waveform::Sine, Some(42));
+        let mut reference = vec![0.0f32; 500];
+        {
+            let mut outputs: [&mut [f32]; 1] = [&mut reference];
+            continuous_osc.process(&inputs, &mut outputs, &[], &context);
+        }
+
+        for (i, (split, cont)) in buffer1.iter().chain(buffer2.iter()).zip(reference.iter()).enumerate() {
+            assert!(
+                (split - cont).abs() < 1e-3,
+                "Split rendering diverges from continuous at sample {}: {} vs {}",
+                i,
+                split,
+                cont
+            );
+        }
+    }
+
+    #[test]
+    fn test_short_slice_noise_f32() {
+        let mut osc = OscillatorBlock::<f32>::new(440.0, Waveform::Noise, Some(42));
+        let context = test_context(512);
+        let inputs: [&[f32]; 0] = [];
+        let mut output = vec![0.0f32; 250];
+        let mut outputs: [&mut [f32]; 1] = [&mut output];
+        osc.process(&inputs, &mut outputs, &[], &context);
     }
 
     #[test]

--- a/bbx_dsp/src/blocks/io/file_input.rs
+++ b/bbx_dsp/src/blocks/io/file_input.rs
@@ -66,7 +66,9 @@ impl<S: Sample> FileInputBlock<S> {
 
 impl<S: Sample> Block<S> for FileInputBlock<S> {
     fn process(&mut self, _inputs: &[&[S]], outputs: &mut [&mut [S]], _modulation_values: &[S], context: &DspContext) {
-        let buffer_size = context.buffer_size;
+        // Advance by the samples actually written so shorter-than-block
+        // slices (e.g. sample-accurate event splitting) don't skip audio
+        let num_samples = outputs.first().map_or(0, |o| o.len()).min(context.buffer_size);
         let num_file_channels = self.reader.num_channels();
         let file_length = self.reader.num_samples();
 
@@ -78,7 +80,7 @@ impl<S: Sample> Block<S> for FileInputBlock<S> {
 
             let input_channel = self.reader.read_channel(channel_index);
 
-            for (sample_index, output_sample) in output_buffer.iter_mut().enumerate() {
+            for (sample_index, output_sample) in output_buffer.iter_mut().take(num_samples).enumerate() {
                 let read_position = self.current_position + sample_index;
                 if read_position < file_length {
                     *output_sample = input_channel[read_position];
@@ -90,7 +92,7 @@ impl<S: Sample> Block<S> for FileInputBlock<S> {
             }
         }
 
-        self.advance_position(buffer_size);
+        self.advance_position(num_samples);
     }
 
     #[inline]
@@ -176,6 +178,33 @@ mod tests {
         for (i, &sample) in output.iter().enumerate() {
             assert!((sample - (i as f32 / 100.0)).abs() < 1e-6);
         }
+    }
+
+    #[test]
+    fn test_file_input_short_slice_advances_by_samples_written() {
+        let samples: Vec<f32> = (0..100).map(|i| i as f32).collect();
+        let reader = MockReader::new(44100.0, vec![samples]);
+        let mut block = FileInputBlock::new(Box::new(reader));
+
+        // Slice is shorter than the context's block size
+        let context = test_context(50);
+        let mut output = vec![0.0f32; 10];
+        {
+            let mut outputs: [&mut [f32]; 1] = [&mut output];
+            block.process(&[], &mut outputs, &[], &context);
+        }
+
+        assert_eq!(block.get_position(), 10);
+
+        {
+            let mut outputs: [&mut [f32]; 1] = [&mut output];
+            block.process(&[], &mut outputs, &[], &context);
+        }
+        assert!(
+            (output[0] - 10.0).abs() < 1e-6,
+            "No samples may be skipped: got {}",
+            output[0]
+        );
     }
 
     #[test]

--- a/bbx_dsp/src/blocks/modulators/envelope.rs
+++ b/bbx_dsp/src/blocks/modulators/envelope.rs
@@ -103,7 +103,11 @@ impl<S: Sample> Block<S> for EnvelopeBlock<S> {
 
         let time_per_sample = 1.0 / context.sample_rate;
 
-        for sample_index in 0..context.buffer_size {
+        // Callers may pass slices shorter than the graph's block size
+        // (e.g. sample-accurate event splitting), so clamp to the slice
+        let num_samples = context.buffer_size.min(outputs[0].len());
+
+        for sample_index in 0..num_samples {
             match self.stage {
                 EnvelopeStage::Idle => {
                     self.level = 0.0;
@@ -196,6 +200,28 @@ mod tests {
         let mut outputs: [&mut [S]; 1] = [&mut output];
         env.process(&inputs, &mut outputs, &[], context);
         output
+    }
+
+    #[test]
+    fn test_envelope_short_slice_advances_by_slice_length_f32() {
+        let mut env = EnvelopeBlock::<f32>::new(0.1, 0.1, 0.5, 0.2);
+        env.note_on();
+
+        // Slice is shorter than the context's block size
+        let context = test_context(512, 44100.0);
+        let inputs: [&[f32]; 0] = [];
+        let mut output = vec![0.0f32; 100];
+        {
+            let mut outputs: [&mut [f32]; 1] = [&mut output];
+            env.process(&inputs, &mut outputs, &[], &context);
+        }
+
+        let expected_level = (100.0 / 44100.0) / 0.1;
+        assert!(
+            (output[99] - expected_level as f32).abs() < 0.01,
+            "Attack should have advanced 100 samples, not buffer_size: level={}",
+            output[99]
+        );
     }
 
     #[test]

--- a/bbx_dsp/src/blocks/modulators/lfo.rs
+++ b/bbx_dsp/src/blocks/modulators/lfo.rs
@@ -55,13 +55,16 @@ impl<S: Sample> Block<S> for LfoBlock<S> {
         let depth = self.depth.get_value(modulation_values).to_f64();
         let phase_increment = frequency.to_f64() / context.sample_rate * S::TAU.to_f64();
 
+        // Callers may pass slices shorter than the graph's block size
+        // (e.g. sample-accurate event splitting), so clamp to the slice
+        let num_samples = context.buffer_size.min(outputs[0].len());
+
         #[cfg(feature = "simd")]
         {
             use crate::waveform::DEFAULT_DUTY_CYCLE;
 
             if !matches!(self.waveform, Waveform::Noise) {
-                let buffer_size = context.buffer_size;
-                let chunks = buffer_size / SIMD_LANES;
+                let chunks = num_samples / SIMD_LANES;
                 let remainder_start = chunks * SIMD_LANES;
                 let chunk_phase_step = phase_increment * SIMD_LANES as f64;
                 let depth_s = S::from_f64(depth);
@@ -109,7 +112,7 @@ impl<S: Sample> Block<S> for LfoBlock<S> {
                 self.phase = self.phase.rem_euclid(S::TAU.to_f64());
 
                 process_waveform_scalar(
-                    &mut outputs[0][remainder_start..],
+                    &mut outputs[0][remainder_start..num_samples],
                     self.waveform,
                     &mut self.phase,
                     phase_increment,
@@ -118,7 +121,7 @@ impl<S: Sample> Block<S> for LfoBlock<S> {
                 );
             } else {
                 process_waveform_scalar(
-                    outputs[0],
+                    &mut outputs[0][..num_samples],
                     self.waveform,
                     &mut self.phase,
                     phase_increment,
@@ -131,7 +134,7 @@ impl<S: Sample> Block<S> for LfoBlock<S> {
         #[cfg(not(feature = "simd"))]
         {
             process_waveform_scalar(
-                outputs[0],
+                &mut outputs[0][..num_samples],
                 self.waveform,
                 &mut self.phase,
                 phase_increment,
@@ -549,6 +552,22 @@ mod tests {
         for &sample in &output {
             assert!(sample.abs() < 1e-12, "Zero depth LFO should produce zero: {}", sample);
         }
+    }
+
+    #[test]
+    fn test_lfo_short_slice_f32() {
+        let mut lfo = LfoBlock::<f32>::new(20.0, 1.0, Waveform::Sine, Some(42));
+        let context = test_context(512, 44100.0);
+        let inputs: [&[f32]; 0] = [];
+
+        // Shorter than buffer_size and not a multiple of the SIMD width
+        let mut output = vec![0.0f32; 250];
+        let mut outputs: [&mut [f32]; 1] = [&mut output];
+        lfo.process(&inputs, &mut outputs, &[], &context);
+
+        let min = output.iter().fold(f32::MAX, |acc, &x| acc.min(x));
+        let max = output.iter().fold(f32::MIN, |acc, &x| acc.max(x));
+        assert!(max - min > 0.01, "Short slice should still produce modulation");
     }
 
     #[test]

--- a/docs/src/contributing/new-blocks.md
+++ b/docs/src/contributing/new-blocks.md
@@ -106,6 +106,14 @@ impl<S: Sample> Block<S> for MyEffectBlock<S> {
 
 ## Key Patterns
 
+### Buffer Length Clamping
+
+`process()` must size every loop by `slice.len().min(context.buffer_size)`, never by
+`context.buffer_size` alone. Callers are allowed to pass slices shorter than the graph's
+block size — for example when splitting a block at MIDI event offsets for sample-accurate
+timing — and indexing by `buffer_size` panics on the shorter slice. Blocks that track a
+position or phase must advance it by the samples actually processed.
+
 ### Parameter Initialization
 
 Parameters combine value source with built-in smoothing:


### PR DESCRIPTION
## Related Issue

None — found while implementing sample-accurate MIDI in `template-plugin`.

## Summary

Callers may legitimately pass output slices shorter than the graph's block size — for example when splitting a block at MIDI event offsets for sample-accurate note timing (as `template-plugin` now does). Four blocks mishandled this while `GainBlock`/`LowPassFilterBlock`/`OverdriveBlock` already clamped correctly:

- **`OscillatorBlock`** / **`LfoBlock`**: the SIMD chunk loop was sized from `context.buffer_size` and indexed past the end of a shorter slice — out-of-range panic on the audio thread
- **`EnvelopeBlock`**: `for sample_index in 0..context.buffer_size` indexed past shorter slices the same way
- **`FileInputBlock`**: wrote the slice but advanced its read position by `buffer_size` regardless, silently skipping (or repeating, with looping) samples on mismatched sizes

All four now process `min(slice_len, context.buffer_size)` samples and advance phase/position by what was actually processed.

Six new regression tests, all exercising a 250-sample slice against a 512 block size (250 also covers the SIMD remainder path); the strongest is oscillator **split-vs-continuous equivalence**: two 250-sample renders must match one continuous 500-sample render. The clamping rule is now stated explicitly in `docs/src/contributing/new-blocks.md`.

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally (`cargo test --workspace --release` with and without `--features simd`; clippy, fmt, mdbook all clean)
- [x] No unrelated changes included