### PR TITLE
chore(release): v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to bbx_audio will be documented in this file.
 
+## [0.5.1] - 2026-08-07
+
+### Bug Fixes
+
+- **dsp**: Clamp block processing to the output slice length (#119) ([#119](https://github.com/blackboxaudio/bbx_audio/pull/119))
+
+### Changed
+
+- **daisy**: Remove the default board feature from `bbx_daisy`; a board feature must now be selected explicitly with `default-features = false`
+
 ## [0.5.0] - 2026-08-06
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,7 @@ checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
 
 [[package]]
 name = "bbx_core"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "libm",
  "loom",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "bbx_daisy"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bbx_core",
  "bbx_dsp",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "bbx_draw"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bbx_core",
  "bbx_dsp",
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "bbx_dsp"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bbx_core",
  "bbx_midi",
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "bbx_file"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bbx_core",
  "bbx_dsp",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "bbx_midi"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bbx_core",
  "midir",
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "bbx_net"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bbx_core",
  "futures-util",
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "bbx_player"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bbx_core",
  "bbx_dsp",
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "bbx_plugin"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bbx_core",
  "bbx_dsp",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "bbx_sandbox"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bbx_core",
  "bbx_dsp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Black Box Audio, LLC"]
 edition = "2024"
 license = "MIT"
@@ -24,14 +24,14 @@ rust-version = "1.89.0"
 [workspace.dependencies]
 # Internal crates (version + path for publishing)
 # Note: default-features = false allows individual crates to opt-in to features
-bbx_core = { version = "0.5.0", path = "bbx_core", default-features = false }
-bbx_daisy = { version = "0.5.0", path = "bbx_daisy" }
-bbx_dsp = { version = "0.5.0", path = "bbx_dsp", default-features = false }
-bbx_file = { version = "0.5.0", path = "bbx_file" }
-bbx_midi = { version = "0.5.0", path = "bbx_midi", default-features = false }
-bbx_net = { version = "0.5.0", path = "bbx_net", default-features = false }
-bbx_player = { version = "0.5.0", path = "bbx_player", default-features = false }
-bbx_plugin = { version = "0.5.0", path = "bbx_plugin" }
+bbx_core = { version = "0.5.1", path = "bbx_core", default-features = false }
+bbx_daisy = { version = "0.5.1", path = "bbx_daisy" }
+bbx_dsp = { version = "0.5.1", path = "bbx_dsp", default-features = false }
+bbx_file = { version = "0.5.1", path = "bbx_file" }
+bbx_midi = { version = "0.5.1", path = "bbx_midi", default-features = false }
+bbx_net = { version = "0.5.1", path = "bbx_net", default-features = false }
+bbx_player = { version = "0.5.1", path = "bbx_player", default-features = false }
+bbx_plugin = { version = "0.5.1", path = "bbx_plugin" }
 
 # External dependencies
 cpal = "0.15.3"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Test](https://github.com/blackboxaudio/bbx_audio/actions/workflows/ci.test.yml/badge.svg)](https://github.com/blackboxaudio/bbx_audio/actions/workflows/ci.test.yml)
 [![Clippy](https://github.com/blackboxaudio/bbx_audio/actions/workflows/ci.clippy.yml/badge.svg)](https://github.com/blackboxaudio/bbx_audio/actions/workflows/ci.clippy.yml)
-[![Version: v0.5.0](https://img.shields.io/badge/Version-v0.5.0-blue.svg)](https://github.com/blackboxaudio/bbx_audio)
+[![Version: v0.5.1](https://img.shields.io/badge/Version-v0.5.1-blue.svg)](https://github.com/blackboxaudio/bbx_audio)
 [![License](https://img.shields.io/badge/License-MIT-yellow)](https://github.com/blackboxaudio/bbx_audio/blob/develop/LICENSE)
 
 A modular, real-time safe audio toolkit in Rust.

--- a/bbx_daisy/README.md
+++ b/bbx_daisy/README.md
@@ -45,7 +45,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bbx_daisy = { version = "0.5.0", default-features = false, features = ["seed"] }
+bbx_daisy = { version = "0.5.1", default-features = false, features = ["seed"] }
 ```
 
 ### Audio Processing
@@ -228,7 +228,7 @@ wait states at 400+ MHz — and the data cache helps data-heavy work (big waveta
 delay lines). If the default already keeps up, leave it off: it's the simpler, verified path.
 
 ```toml
-bbx_daisy = { version = "0.5.0", default-features = false, features = ["seed", "dcache"] }
+bbx_daisy = { version = "0.5.1", default-features = false, features = ["seed", "dcache"] }
 ```
 
 **Before shipping with it on:**

--- a/bbx_net/client/package.json
+++ b/bbx_net/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bbx-audio/net",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "description": "Lightweight client for websocket-based audio control with the bbx_net 🌐",
     "private": false,
     "license": "MIT",

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -11,29 +11,29 @@ Add the crates you need to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bbx_dsp = "0.5.0"
-bbx_core = "0.5.0"
+bbx_dsp = "0.5.1"
+bbx_core = "0.5.1"
 ```
 
 For JUCE plugin integration, you'll only need:
 
 ```toml
 [dependencies]
-bbx_plugin = "0.5.0"
+bbx_plugin = "0.5.1"
 ```
 
 For audio file I/O:
 
 ```toml
 [dependencies]
-bbx_file = "0.5.0"
+bbx_file = "0.5.1"
 ```
 
 For MIDI support:
 
 ```toml
 [dependencies]
-bbx_midi = "0.5.0"
+bbx_midi = "0.5.1"
 ```
 
 ## Using Git Dependencies

--- a/docs/src/tutorials/terminal-synth.md
+++ b/docs/src/tutorials/terminal-synth.md
@@ -40,7 +40,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-bbx_dsp = "0.5.0"
+bbx_dsp = "0.5.1"
 rodio = "0.20.1"
 ```
 
@@ -165,7 +165,7 @@ Add the `bbx_dsp` block import:
 
 ```toml
 [dependencies]
-bbx_dsp = "0.5.0"
+bbx_dsp = "0.5.1"
 rodio = "0.20.1"
 ```
 
@@ -248,7 +248,7 @@ Update `Cargo.toml`:
 
 ```toml
 [dependencies]
-bbx_dsp = "0.5.0"
+bbx_dsp = "0.5.1"
 bbx_midi = "0.1.0"
 rodio = "0.20.1"
 midir = "0.11"


### PR DESCRIPTION
## Related Issue

None — release bump for the changes merged in #119.

## Summary

Lockstep patch bump of all crates (and `@bbx-audio/net`) from 0.5.0 to 0.5.1, carrying the short-slice block processing fix (#119) and the removal of `bbx_daisy`'s default board feature.

- Root `Cargo.toml`: `workspace.package` version and all internal dependency versions
- `bbx_net/client/package.json`: 0.5.1 (the npm publish job releases whatever version it holds)
- README badge, `bbx_daisy` README snippets, and docs (`installation.md`, `terminal-synth.md`) version references
- CHANGELOG entry via git-cliff, plus a manual entry for the `bbx_daisy` default-feature removal (non-conventional commit message, so git-cliff skipped it)

On squash-merge, CI extracts `v0.5.1` from the branch name, tags, publishes to crates.io in dependency order, publishes npm, and opens the `develop` → `main` sync PR.

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally (`cargo test --workspace --release` green; `cargo publish --dry-run` passes for `bbx_core` — dependents fail only on the not-yet-published 0.5.1 versions, which the ordered CI publish resolves)
- [x] No unrelated changes included